### PR TITLE
Add services command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1186,6 +1186,7 @@ checksum = "c7cb5678e1615754284ec264d9bb5b4c27d2018577fd90ac0ceb578591ed5ee4"
 [[package]]
 name = "straitjacket"
 version = "0.1.0"
+source = "git+https://github.com/3scale-rs/straitjacket#7ebcdaa25ae96d32468af4f609052bb9ce7f2318"
 dependencies = [
  "http",
  "lazy_static",
@@ -1199,7 +1200,7 @@ dependencies = [
 [[package]]
 name = "straitjacket_macro"
 version = "0.1.0"
-source = "git+https://github.com/3scale-rs/straitjacket_macro?rev=5469b195b4ec76a8f6c4b0a14d98f2d49577ac69#5469b195b4ec76a8f6c4b0a14d98f2d49577ac69"
+source = "git+https://github.com/3scale-rs/straitjacket_macro#590161cb16c45488bb58f8c9c66764e197e58c50"
 dependencies = [
  "Inflector",
  "proc-macro2",


### PR DESCRIPTION
This is a pretty quick and dirty PoC for a new `services` command that just knows how to call into Porta, retrieve services and display them in a session.

```
api 0.1.0 (2020-05-29) - UNKNOWN for x86_64-unknown-linux-gnu

No previous history.
>> host https://istiodevel-admin.3scale.net
Ok.
https://istiodevel-admin.3scale.net/>> token <redacted>
Ok.
https://istiodevel-admin.3scale.net/>> services
Ok, response status 200 OK.
Svc: 2555417760888 test AppIdKey Some(Hosted) This API is not managed by the Threescale API operator
Svc: 2555417764324 hello-world APIKey Some(ServiceMeshIstio) Hi world :D
Svc: 2555417777820 echo-api APIKey Some(SelfManaged) Echo API
Svc: 2555417783508 bookinfo APIKey Some(ServiceMeshIstio) 
Svc: 2555417814278 phala-test APIKey Some(Hosted) 
Svc: 2555417834780 gol-api APIKey Some(PluginRest) Game of Life API
https://istiodevel-admin.3scale.net/>> 
```